### PR TITLE
Fix compilation problems, and removed an undefined hash 

### DIFF
--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -160,7 +160,7 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 
 	if (padding == CSSM_PADDING_PKCS1) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  PKCS#1 padding\n");
-		//flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
+		flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
 	}
 	else if (padding == CSSM_PADDING_NONE) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO padding\n");

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -155,7 +155,7 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 	// Get padding, but default to pkcs1 style padding for RSA
 	if (context.algorithm() == CSSM_ALGID_RSA) {
 		padding = CSSM_PADDING_PKCS1;
-		context.getInt(CSSM_ATTRIBUTE_PADDING, padding);
+		padding = context.getInt(CSSM_ATTRIBUTE_PADDING, padding);
 	}
 
 	if (padding == CSSM_PADDING_PKCS1) {

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -68,154 +68,171 @@ uint32 inputSize, bool encrypting)
 }
 
 
-void OpenSCKeyHandle::generateSignature(const Context &context,
+void OpenSCKeyHandle::generateRsaSignature(const Context &context,
 CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 {
-	// for sc_pkcs15_compute_signature()
 	unsigned int flags = 0;
 
-	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCKeyHandle::generateSignature()\n");
-
-	if (context.type() == CSSM_ALGCLASS_SIGNATURE) {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  type == CSSM_ALGCLASS_SIGNATURE\n");
-	}
-	else {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Unknown type: 0x%0x, exiting\n", context.type());
-		CssmError::throwMe(CSSMERR_CSP_INVALID_CONTEXT);
-	}
-
-	if (context.algorithm() == CSSM_ALGID_RSA) {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  algorithm == CSSM_ALGID_RSA\n");
-	}
-	else if (context.algorithm() == CSSM_ALGID_ECDSA) {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  algorithm == CSSM_ALGID_ECDSA\n");
-	}
-   	else {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Unknown algorithm: 0x%0x, exiting\n", context.algorithm());
+	if (mKey.signKey()->type != SC_PKCS15_TYPE_PRKEY_RSA)
 		CssmError::throwMe(CSSMERR_CSP_INVALID_ALGORITHM);
+
+	// default to pkcs1 style padding
+	switch(context.getInt(CSSM_ATTRIBUTE_PADDING, CSSM_PADDING_PKCS1)) {
+		case CSSM_PADDING_NONE:
+			flags |= SC_ALGORITHM_RSA_PAD_NONE;
+			break;
+		case CSSM_PADDING_PKCS1:
+			flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
+			break;
+		default:
+			CssmError::throwMe(CSSMERR_CSP_INVALID_ATTR_PADDING);
 	}
 
-	if (signOnly == CSSM_ALGID_SHA1) {
-
-		if (input.Length != 20)
-			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
-		flags |= SC_ALGORITHM_RSA_HASH_SHA1;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA1, length is 20 bytes\n");
-	}
-	else if (signOnly == CSSM_ALGID_MD5) {
-		if (input.Length != 16)
-			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
-		flags |= SC_ALGORITHM_RSA_HASH_MD5;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using MD5, length is 16 bytes\n");
-	}
-   	else if (signOnly == CSSM_ALGID_SHA256) {
-		if (input.Length != 32)
-			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
-		flags |= SC_ALGORITHM_RSA_HASH_SHA256;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA256, length is 32 bytes\n");
-	}
-   	else if (signOnly == CSSM_ALGID_SHA384) {
-		if (input.Length != 48)
-			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
-		flags |= SC_ALGORITHM_RSA_HASH_SHA384;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA384, length is 48 bytes\n");
-	}
-   	else if (signOnly == CSSM_ALGID_SHA512) {
-		if (input.Length != 64)
-			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
-		flags |= SC_ALGORITHM_RSA_HASH_SHA512;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA512, length is 64 bytes\n");
-	}
-	else if (signOnly == CSSM_ALGID_NONE) {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO digest (perhaps for SSL authentication)\n");
-		flags |= SC_ALGORITHM_RSA_HASH_NONE;
-	}
-	else {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Unknown signOnly value: 0x%0x, exiting\n", signOnly);
-		CssmError::throwMe(CSSMERR_CSP_INVALID_DIGEST_ALGORITHM);
+	switch (signOnly) {
+		case CSSM_ALGID_MD5:
+			if (input.Length != 16)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_RSA_HASH_MD5;
+			break;
+		case CSSM_ALGID_SHA1:
+			if (input.Length != 20)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_RSA_HASH_SHA1;
+			break;
+		case CSSM_ALGID_SHA256:
+			if (input.Length != 32)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_RSA_HASH_SHA256;
+			break;
+		case CSSM_ALGID_SHA384:
+			if (input.Length != 48)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_RSA_HASH_SHA384;
+			break;
+		case CSSM_ALGID_SHA512:
+			if (input.Length != 64)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_RSA_HASH_SHA512;
+			break;
+		case CSSM_ALGID_NONE:
+			sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO digest (perhaps for SSL authentication)\n");
+			flags |= SC_ALGORITHM_RSA_HASH_NONE;
+			break;
+		default:
+			sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Unknown signOnly value: 0x%0x, exiting\n", signOnly);
+			CssmError::throwMe(CSSMERR_CSP_INVALID_DIGEST_ALGORITHM);
 	}
 
-	// Consistency validation - necessary for MS Outlook 2011 that seems
-	// to ask for RSA signatures with EC keys.
-	if ((context.algorithm() == CSSM_ALGID_ECDSA
-				&& mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_RSA)
-		   	|| (context.algorithm() == CSSM_ALGID_RSA
-			   	&& mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_EC))
-	{
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
-				"  Illegal combination of key type %s and requested algorithm %s\n",
-				(const char *)(mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_RSA?
-					"PRKEY_RSA" : "PRKEY_EC"),
-				(const char *)(context.algorithm() == CSSM_ALGID_ECDSA? "EDCSA" : "RSA")
-				);
-		CssmError::throwMe(CSSMERR_CSP_INVALID_ALGORITHM);
-	}
-
-	uint32 padding = CSSM_PADDING_NONE;
-	// Get padding, but default to pkcs1 style padding for RSA
-	if (context.algorithm() == CSSM_ALGID_RSA) {
-		padding = CSSM_PADDING_PKCS1;
-		padding = context.getInt(CSSM_ATTRIBUTE_PADDING, padding);
-	}
-
-	if (padding == CSSM_PADDING_PKCS1) {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  PKCS#1 padding\n");
-		flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
-	}
-	else if (padding == CSSM_PADDING_NONE) {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO padding\n");
-	}
-	else {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Unknown padding 0x%0x, exiting\n", padding);
-		CssmError::throwMe(CSSMERR_CSP_INVALID_ATTR_PADDING);
-	}
-
-	// Modulus size in bits for RSA, or field len in bits for EC
+	// Modulus size in bits
 	size_t sig_len = (mKey.sizeInBits() + 7) / 8;
-	if (mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_EC)
-		sig_len *= 2; // doubling ECC field size for ECDSA
-	// @@@ Switch to using tokend allocators
-	unsigned char *outputData =
-		reinterpret_cast<unsigned char *>(malloc(sig_len));
+	unsigned char *outputData = reinterpret_cast<unsigned char *>(malloc(sig_len));
 	if (outputData == NULL)
 		CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
 
-	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
-			"  Signing buffers: inlen=%d, outlen=%d\n",input.Length, sig_len);
 	// Call OpenSC to do the actual signing
-	int rv = sc_pkcs15_compute_signature(mToken.mScP15Card,
-			mKey.signKey(), flags, input.Data, input.Length, outputData, sig_len);
-	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_compute_signature(): rv = %d\n", rv);
-	if (rv < 0) {
+	if (0 > sc_pkcs15_compute_signature(mToken.mScP15Card, mKey.signKey(),
+				flags, input.Data, input.Length, outputData, sig_len); {
 		free(outputData);
 		CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
 	}
 
-	if (mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_EC)
-	{
-		// Wrap the result of compute_signature() as ASN.1 SEQUENCE
-		unsigned char *seq;
-		size_t seqlen;
-		if (sc_asn1_sig_value_rs_to_sequence(mToken.mScCtx, outputData, sig_len, &seq, &seqlen))   {
-			sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
-					"Failed to convert signature to ASN1 sequence format.\n");
-			free(outputData);
-			CssmError::throwMe(CSSMERR_CSP_INVALID_OUTPUT_VECTOR);
-		}
+	signature.Data = outputData;
+	signature.Length = rv;
+}
+
+
+void OpenSCKeyHandle::generateEcdsaSignature(const Context &context,
+CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
+{
+	if (mKey.signKey()->type != SC_PKCS15_TYPE_PRKEY_EC)
+		CssmError::throwMe(CSSMERR_CSP_INVALID_ALGORITHM);
+
+	if (CSSM_PADDING_NONE != context.getInt(CSSM_ATTRIBUTE_PADDING,
+				CSSM_PADDING_NONE))
+		CssmError::throwMe(CSSMERR_CSP_INVALID_ATTR_PADDING);
+
+	switch (signOnly) {
+		case CSSM_ALGID_MD5:
+			if (input.Length != 16)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_ECDSA_HASH_MD5;
+			break;
+		case CSSM_ALGID_SHA1:
+			if (input.Length != 20)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_ECDSA_HASH_SHA1;
+			break;
+		case CSSM_ALGID_SHA256:
+			if (input.Length != 32)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_ECDSA_HASH_SHA256;
+			break;
+		case CSSM_ALGID_SHA384:
+			if (input.Length != 48)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_ECDSA_HASH_SHA384;
+			break;
+		case CSSM_ALGID_SHA512:
+			if (input.Length != 64)
+				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+			flags |= SC_ALGORITHM_ECDSA_HASH_SHA512;
+			break;
+		case CSSM_ALGID_NONE:
+			sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO digest (perhaps for SSL authentication)\n");
+			flags |= SC_ALGORITHM_ECDSA_HASH_NONE;
+			break;
+		default:
+			CssmError::throwMe(CSSMERR_CSP_INVALID_DIGEST_ALGORITHM);
+			sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Unknown signOnly value: 0x%0x, exiting\n", signOnly);
+	}
+
+	// double of field size in bytes
+	size_t sig_len = 2*((mKey.sizeInBits() + 7) / 8);
+	unsigned char *outputData = reinterpret_cast<unsigned char *>(malloc(sig_len));
+	if (outputData == NULL)
+		CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
+
+	if (0 > sc_pkcs15_compute_signature(mToken.mScP15Card, mKey.signKey(),
+				flags, input.Data, input.Length, outputData, sig_len)) {
 		free(outputData);
-		signature.Data = reinterpret_cast<unsigned char *>(malloc(seqlen));
-		if (signature.Data == NULL)
-			CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
-		signature.Length = seqlen;
-		memcpy(signature.Data, seq, seqlen);
-		free(seq);
+		CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
+	}
+
+	// Wrap the result of compute_signature() as ASN.1 SEQUENCE
+	unsigned char *seq = NULL;
+	size_t seqlen = 0;
+	if (sc_asn1_sig_value_rs_to_sequence(mToken.mScCtx, outputData, sig_len, &seq, &seqlen))   {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
-				"  Converted ECDSA signature to ASN.1 SEQUENCE: seqlen=%d\n",
-				seqlen);
-	} else {
-		// For RSA just pass along the return of sc_pkcs15_compute_signature()
-		signature.Data = outputData;
-		signature.Length = rv;
+				"Failed to convert signature to ASN1 sequence format.\n");
+		free(outputData);
+		CssmError::throwMe(CSSMERR_CSP_INVALID_OUTPUT_VECTOR);
+	}
+	free(outputData);
+
+	signature.Data = seq;
+	signature.Length = seqlen;
+}
+
+
+void OpenSCKeyHandle::generateSignature(const Context &context,
+CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
+{
+	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCKeyHandle::generateSignature()\n");
+
+	if (context.type() != CSSM_ALGCLASS_SIGNATURE) {
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  ALGCLASS_SIGNATURE Unknown type: 0x%0x, exiting\n", context.type());
+		CssmError::throwMe(CSSMERR_CSP_INVALID_CONTEXT);
+	}
+
+	switch (context.algorithm()) {
+		case CSSM_ALGID_RSA:
+			generateRsaSignature(context, signOnly, input, signature);
+			break;
+		case CSSM_ALGID_ECDSA:
+			generateEcdsaSignature(context, signOnly, input, signature);
+			break;
+		default:
+			CssmError::throwMe(CSSMERR_CSP_INVALID_ALGORITHM);
 	}
 }
 

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -131,19 +131,22 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 
 	// Call OpenSC to do the actual signing
 	if (0 > sc_pkcs15_compute_signature(mToken.mScP15Card, mKey.signKey(),
-				flags, input.Data, input.Length, outputData, sig_len); {
+				flags, input.Data, input.Length, outputData, sig_len))
+	{
 		free(outputData);
 		CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
 	}
 
 	signature.Data = outputData;
-	signature.Length = rv;
+	signature.Length = sig_len;
 }
 
 
 void OpenSCKeyHandle::generateEcdsaSignature(const Context &context,
 CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 {
+	unsigned int flags = 0;
+
 	if (mKey.signKey()->type != SC_PKCS15_TYPE_PRKEY_EC)
 		CssmError::throwMe(CSSMERR_CSP_INVALID_ALGORITHM);
 
@@ -152,11 +155,6 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		CssmError::throwMe(CSSMERR_CSP_INVALID_ATTR_PADDING);
 
 	switch (signOnly) {
-		case CSSM_ALGID_MD5:
-			if (input.Length != 16)
-				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
-			flags |= SC_ALGORITHM_ECDSA_HASH_MD5;
-			break;
 		case CSSM_ALGID_SHA1:
 			if (input.Length != 20)
 				CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);

--- a/OpenSC/OpenSCKeyHandle.h
+++ b/OpenSC/OpenSCKeyHandle.h
@@ -44,7 +44,7 @@ class OpenSCKeyRecord;
 class OpenSCKeyHandle: public Tokend::KeyHandle
 {
 	NOCOPY(OpenSCKeyHandle)
-		public:
+	public:
 		OpenSCKeyHandle(OpenSCToken &OpenSCToken,
 			const Tokend::MetaRecord &metaRecord, OpenSCKeyRecord &cacKey);
 		~OpenSCKeyHandle();
@@ -63,6 +63,12 @@ class OpenSCKeyHandle: public Tokend::KeyHandle
 		virtual void decrypt(const Context &context, const CssmData &cipher, CssmData &clear);
 
 		virtual void exportKey(const Context &context, const AccessCredentials *cred, CssmKey &wrappedKey);
+
+	protected:
+		virtual void generateRsaSignature(const Context &context,
+			CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature);
+		virtual void generateEcdsaSignature(const Context &context,
+			CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature);
 
 	private:
 		OpenSCToken &mToken;

--- a/OpenSC/OpenSCRecord.cpp
+++ b/OpenSC/OpenSCRecord.cpp
@@ -98,7 +98,11 @@ void OpenSCCertificateRecord::getAcl(const char *tag, uint32 &count, AclEntryInf
 size_t OpenSCKeyRecord::sizeInBits() const
 {
 	sc_pkcs15_prkey_info *prkey = (sc_pkcs15_prkey_info *)mPrKeyObj->data;
-	return prkey->modulus_length;
+	if (mPrKeyObj->type == SC_PKCS15_TYPE_PRKEY_EC)
+		return prkey->field_length; /* EC field length in bits */
+	else
+		return prkey->modulus_length; /* RSA modulus length in bits */
+	// FIXME - need to address DSA keys too
 }
 
 /************************** OpenSCKeyRecord *****************************/

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -445,7 +445,6 @@ void OpenSCToken::populate()
 	KeyCountMap mKeys;
 	
 	// Locate certificates
-	//FIXME - max objects constant ?
 	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_CERT_X509, objs, 32);
 	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_CERT_X509): %d\n", r);
 	if (r >= 0) {
@@ -463,8 +462,8 @@ void OpenSCToken::populate()
 	}
 
 	// Locate private keys
-	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_PRKEY_RSA, objs, 32);
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_PRKEY_RSA): %d\n", r);
+	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_PRKEY, objs, 32);
+	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_PRKEY): %d\n", r);
 	if (r >= 0) {
 		
 		// Count the occurences of the private key ids


### PR DESCRIPTION
@frankmorgner I suggest that this fix is better for several reasons:
1. It sets the correct signature length (I'm not sure that `sc_pkcs15_compute_signature()` returns the length of the output data).
2. It removes SC_ALGORITHM_ECDSA_HASH_MD5 which has not been defined (I think MD5 has been prohibited by the time ECDSA came about).
