### PR TITLE
Improves support for PIV tokens, adds SHA-2 and ECDSA

### DIFF
--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -160,7 +160,7 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 
 	if (padding == CSSM_PADDING_PKCS1) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  PKCS#1 padding\n");
-		//flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
+		flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
 	}
 	else if (padding == CSSM_PADDING_NONE) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO padding\n");

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -261,26 +261,63 @@ const CssmData &cipher, CssmData &clear)
 	if (context.type() != CSSM_ALGCLASS_ASYMMETRIC)
 		CssmError::throwMe(CSSMERR_CSP_INVALID_CONTEXT);
 
-	if (context.algorithm() != CSSM_ALGID_RSA)
+	if ((context.algorithm() != CSSM_ALGID_RSA) &&
+            (context.algorithm() != CSSM_ALGID_ECDH))
 		CssmError::throwMe(CSSMERR_CSP_INVALID_ALGORITHM);
 
 	// @@@ Switch to using tokend allocators
-	unsigned char *outputData =
+        unsigned char *outputData = NULL;
 		reinterpret_cast<unsigned char *>(malloc(cipher.Length));
-	if (outputData == NULL)
-		CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
-
+	
 	// Call OpenSC to do the actual decryption
-	int rv = sc_pkcs15_decipher(mToken.mScP15Card,
-		mKey.decryptKey(), SC_ALGORITHM_RSA_PAD_PKCS1,
-		cipher.Data, cipher.Length, outputData, cipher.Length);
-	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_decipher(): rv = %d\n", rv);
-	if (rv < 0) {
-		free(outputData);
-		CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
-	}
-	clear.Data = outputData;
-	clear.Length = rv;
+        int rv = -1; // return code
+        unsigned long output_len = 0; // needed for ECDH
+        
+        if (context.algorithm() == CSSM_ALGID_RSA) {
+                // RSA decryption
+                outputData =
+                	reinterpret_cast<unsigned char *>(malloc(cipher.Length));
+                if (outputData == NULL)
+                        CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
+		rv = sc_pkcs15_decipher(mToken.mScP15Card,
+			mKey.decryptKey(), SC_ALGORITHM_RSA_PAD_PKCS1,
+			cipher.Data, cipher.Length, outputData, cipher.Length);
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                         "  sc_pkcs15_decipher(): rv = %d\n", rv);
+		if (rv < 0) {
+			free(outputData);
+			CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
+		}
+		clear.Data = outputData;
+		clear.Length = rv;
+        }
+        else {
+                // ECDH key derivation
+                // First get length of the derived key
+                rv = sc_pkcs15_derive(mToken.mScP15Card,
+	                        mKey.decryptKey(), SC_ALGORITHM_ECDH_CDH_RAW,
+                                cipher.Data, cipher.Length, NULL, &output_len);
+                sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                         "  sc_pkcs15_derive() told us to allocate %d bytes\n",
+                         output_len);
+                outputData =
+	                reinterpret_cast<unsigned char *>(malloc(output_len));
+                if (outputData == NULL)
+                        CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
+
+                rv = sc_pkcs15_derive(mToken.mScP15Card,
+                        mKey.decryptKey(), SC_ALGORITHM_ECDH_CDH_RAW,
+                        cipher.Data, cipher.Length, outputData, &output_len);
+                sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                         "  sc_pkcs15_derive(): rv = %d\n", rv);
+                if (rv < 0) {
+                        free(outputData);
+                        CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
+                }
+                clear.Data = outputData;
+                clear.Length = output_len;
+
+        }
 
 	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  decrypt(): returning with %d decrypted bytes%d\n", clear.Length);
 }

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -160,7 +160,7 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 
 	if (padding == CSSM_PADDING_PKCS1) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  PKCS#1 padding\n");
-		flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
+		flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
 	}
 	else if (padding == CSSM_PADDING_NONE) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO padding\n");
@@ -191,9 +191,13 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
 	}
 
-	if (mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_EC)
+	if (mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_RSA)
 	{
-		// Wrap the result of compute_signature() as ASN.1 SEQUENCE
+                // For RSA just pass along the return of sc_pkcs15_compute_signature()
+                signature.Data = outputData;
+                signature.Length = rv;
+        } else {
+		// For ECDSA wrap the result of compute_signature() as ASN.1 SEQUENCE
 		unsigned char *seq;
 		size_t seqlen;
 		if (sc_asn1_sig_value_rs_to_sequence(mToken.mScCtx, outputData, sig_len, &seq, &seqlen))   {
@@ -212,10 +216,6 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
 				"  Converted ECDSA signature to ASN.1 SEQUENCE: seqlen=%d\n",
 				seqlen);
-	} else {
-		// For RSA just pass along the return of sc_pkcs15_compute_signature()
-		signature.Data = outputData;
-		signature.Length = rv;
 	}
 }
 

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -30,6 +30,7 @@
 #include <security_utilities/utilities.h>
 #include <security_cdsa_utilities/cssmerrors.h>
 #include <Security/cssmerr.h>
+#include <Security/cssmapple.h>
 
 #include "libopensc/log.h"
 /************************** OpenSCKeyHandle ************************/
@@ -95,14 +96,31 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		if (input.Length != 20)
 			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
 		flags |= SC_ALGORITHM_RSA_HASH_SHA1;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA1, length is 20\n");
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA1, length is 20 bytes\n");
 	}
 	else if (signOnly == CSSM_ALGID_MD5) {
 		if (input.Length != 16)
 			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
 		flags |= SC_ALGORITHM_RSA_HASH_MD5;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using MD5, length is 16\n");
-
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using MD5, length is 16 bytes\n");
+	}
+   	else if (signOnly == CSSM_ALGID_SHA256) {
+		if (input.Length != 32)
+			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+		flags |= SC_ALGORITHM_RSA_HASH_SHA256;
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA256, length is 32 bytes\n");
+	}
+   	else if (signOnly == CSSM_ALGID_SHA384) {
+		if (input.Length != 48)
+			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+		flags |= SC_ALGORITHM_RSA_HASH_SHA384;
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA384, length is 48 bytes\n");
+	}
+   	else if (signOnly == CSSM_ALGID_SHA512) {
+		if (input.Length != 64)
+			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+		flags |= SC_ALGORITHM_RSA_HASH_SHA512;
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA512, length is 64 bytes\n");
 	}
 	else if (signOnly == CSSM_ALGID_NONE) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO digest (perhaps for SSL authentication)\n");

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -131,7 +131,8 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		flags |= SC_ALGORITHM_RSA_HASH_NONE;
 	}
 	else {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Unknown signOnly value: 0x%0x, exiting\n", signOnly);
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                         "  Unknown signOnly value: 0x%0x, exiting\n", signOnly);
 		CssmError::throwMe(CSSMERR_CSP_INVALID_DIGEST_ALGORITHM);
 	}
 
@@ -186,6 +187,7 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 
 	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
 		"  Signing buffers: inlen=%d, outlen=%d\n",input.Length, sig_len);
+        
 	// Call OpenSC to do the actual signing (RSA or ECDSA)
 	int rv = sc_pkcs15_compute_signature(mToken.mScP15Card,
 					     mKey.signKey(), flags,
@@ -207,7 +209,10 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		// For ECDSA wrap the result of compute_signature() as ASN.1 SEQUENCE
 		unsigned char *seq;
 		size_t seqlen;
-		if (sc_asn1_sig_value_rs_to_sequence(mToken.mScCtx, outputData, sig_len, &seq, &seqlen))   {
+		if (sc_asn1_sig_value_rs_to_sequence(mToken.mScCtx,
+                                                     outputData, sig_len,
+                                                     &seq, &seqlen))
+                {
 			sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
 				"Failed to convert signature to ASN1 sequence format.\n");
 			free(outputData);
@@ -263,7 +268,8 @@ void OpenSCKeyHandle::decrypt(const Context &context,
 const CssmData &cipher, CssmData &clear)
 {
 	secdebug("crypto", "decrypt alg: %lu", (long unsigned int) context.algorithm());
-	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCKeyHandle::decrypt(ciphertext length = %d)\n", cipher.Length);
+	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                 "In OpenSCKeyHandle::decrypt(ciphertext length = %d)\n", cipher.Length);
 	
 	if (context.type() != CSSM_ALGCLASS_ASYMMETRIC)
 		CssmError::throwMe(CSSMERR_CSP_INVALID_CONTEXT);
@@ -284,8 +290,8 @@ const CssmData &cipher, CssmData &clear)
 
 	// Determine padding
 	unsigned int flags = 0;
-	unsigned int padding = 0;
-	padding = context.getInt(CSSM_ATTRIBUTE_PADDING, CSSMERR_CSP_INVALID_ATTR_PADDING);
+	unsigned int padding = context.getInt(CSSM_ATTRIBUTE_PADDING,
+                                              CSSMERR_CSP_INVALID_ATTR_PADDING);
 	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "   got padding=%d 0x%X\n",
 		 padding, padding);
 	if (padding == CSSM_PADDING_PKCS1)

--- a/OpenSC/OpenSCRecord.cpp
+++ b/OpenSC/OpenSCRecord.cpp
@@ -98,7 +98,11 @@ void OpenSCCertificateRecord::getAcl(const char *tag, uint32 &count, AclEntryInf
 size_t OpenSCKeyRecord::sizeInBits() const
 {
 	sc_pkcs15_prkey_info *prkey = (sc_pkcs15_prkey_info *)mPrKeyObj->data;
-	return prkey->modulus_length;
+	if (mPrKeyObj->type == SC_PKCS15_TYPE_PRKEY_EC)
+		return prkey->field_length; /* EC field length in bits */
+	else
+		return prkey->modulus_length; /* RSA modulus length in bits */
+	// FIXME - need to address DSA keys too
 }
 
 /************************** OpenSCKeyRecord *****************************/

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -445,7 +445,6 @@ void OpenSCToken::populate()
 	KeyCountMap mKeys;
 	
 	// Locate certificates
-	//FIXME - max objects constant ?
 	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_CERT_X509, objs, 32);
 	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_CERT_X509): %d\n", r);
 	if (r >= 0) {
@@ -463,8 +462,8 @@ void OpenSCToken::populate()
 	}
 
 	// Locate private keys
-	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_PRKEY_RSA, objs, 32);
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_PRKEY_RSA): %d\n", r);
+	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_PRKEY, objs, 32);
+	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_PRKEY): %d\n", r);
 	if (r >= 0) {
 		
 		// Count the occurences of the private key ids


### PR DESCRIPTION
This PR provides:
1. Improved support for PIV tokens, which was completely broken until @frankmorgner fixed it and updated his fork.
2. Complete support for SHA-2, which does not work in other forks (as far as I was able to test).
3. Support for ECDSA.
4. Base code for ECDH: decrypt() now calls `sc_pkcs15_derive()`, but ECDH is not supported yet, and not been tested because there is no application that I know of that uses it. Would be happy to re-open this issue, and improve/fix the ECDH processing.

RSA is fully supported, and has been tested with Keychain Access, Apple Mail on Yosemite and El Capitan, MS Outlook 2011 (Yosemite and El Capitan). Both interoperated with Thunderbird (same platforms - but Thunderbird does not use tokend). Also, interoperated with Blackberry Classic (a different S/MIME implementation, and a good validation test).

ECDSA was tested with Apple Mail against Thunderbird. MS Outlook 2011 could validate ECDSA signatures, but could not produce them (deficiency of the Outlook itself - it keeps asking for RSA-based signature algorithms even when the provided key is ECC).
